### PR TITLE
Add ForcedLowerCase setting for KnownSources

### DIFF
--- a/src/Globot.Web/App/Services/GlobotUploadWorker.cs
+++ b/src/Globot.Web/App/Services/GlobotUploadWorker.cs
@@ -75,6 +75,9 @@ public class GlobotUploadWorker
 
     private async Task UploadGlob(string knownSourceName, DirectoryInfo sourceDir, FilePatternMatch file, GlobotFileManifest manifest, BlobContainerClient container, CancellationToken cancellationToken)
     {
+        var knownSource = _globot.KnownSources[knownSourceName];
+        var forceLowerCase = knownSource.ForceLowerCase != null && knownSource.ForceLowerCase.Value;
+
         var sourceFileName = Path.Combine(sourceDir.FullName, file.Path);
         var sourceFileInfo = new FileInfo(sourceFileName);
 
@@ -85,7 +88,7 @@ public class GlobotUploadWorker
         }
         
         string mimeType = MimeTypes.GetMimeType(sourceFileName);
-        string destBlobName = file.Path.ToLowerInvariant();
+        string destBlobName = forceLowerCase ? file.Path.ToLowerInvariant() : file.Path;
         string blobPath = Path
             .Combine(knownSourceName, destBlobName)
             .Replace("\\", "/");

--- a/src/Globot.Web/Configuration/GlobotConfiguration.cs
+++ b/src/Globot.Web/Configuration/GlobotConfiguration.cs
@@ -28,6 +28,7 @@ public class GlobotConfiguration
     {
         public string? Path {get;set;}
         public string[]? FileExtensions { get; set; }
+        public bool? ForceLowerCase { get; set; }
     }
 
     public class BlobServiceClientConfiguration


### PR DESCRIPTION
This PR adds a new setting key for KnownSources to explicitly enable/disable lowercasing of file names.

Sample config:

```json
{
  "Globot" : {
    ...

    "KnownSources": {
      "TestForceLowerCase": {
        "Path": "E:\\devpaths\\Globot\\TestForceLowerCase",
        "ForceLowerCase": true
      },
      "TestDefault": {
        "Path": "E:\\devpaths\\Globot\\TestDefault"
      },
      "TestLimitedFileExtensions": {
        "Path": "E:\\devpaths\\Globot\\TestLimitedFileExtensions",
        "FileExtensions" : ["*.css", "*.js"]
      }
    }
  }
}

```